### PR TITLE
Bug fixed: memory of previous result during multiple inputs

### DIFF
--- a/calcmass/__main__.py
+++ b/calcmass/__main__.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import mass
-import argparse
+from calcmass import argparse
 
 
 def main():

--- a/calcmass/__main__.py
+++ b/calcmass/__main__.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from calcmass import mass
+import mass
 import argparse
 
 
@@ -20,7 +20,7 @@ def main():
         else:
             raise argparse.ArgumentParser.error(parser, 'Not a compound: ' +
                                                 mass.calculate(elements))
-
+        mass.multiples.clear()
 
 if __name__ == "__main__":
     main()

--- a/calcmass/mass.py
+++ b/calcmass/mass.py
@@ -4,7 +4,6 @@ from pt_data import masses
 val = ""
 multiples = {}
 
-
 def add_commas(orig):
     with_Commas = ""
     for i in range(len(orig) - 1):
@@ -79,7 +78,6 @@ def add_markers(val):
 
 # adds coefficients and symbol to the multiples dictionary
 def add(mult, symb):
-    global multiples
     com = symb.find(",")
     if com >= 0:
         symb = symb[:com]


### PR DESCRIPTION
```
$ calcmass H H H  
H: 1.00794  
H: 2.01588  
H: 3.02382
```
First, dictionary is a mutable object in Python, so you don't have to use 'global'.

As you use a dictionary to count during the calculation and you allow the script to receive multiple arguments, you have to reset such dictionary after the calculation.

```
python3 __main__.py H H H2O
H: 1.00794
H: 1.00794
H2O: 18.01528
```