### PR TITLE
numbers don't have to be integers in a chemical formula

### DIFF
--- a/calcmass/__main__.py
+++ b/calcmass/__main__.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from calcmass import mass
+import mass
 import argparse
 
 

--- a/calcmass/__main__.py
+++ b/calcmass/__main__.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import mass
+from calcmass import mass
 import argparse
 
 

--- a/calcmass/mass.py
+++ b/calcmass/mass.py
@@ -34,7 +34,7 @@ def distribute(val, num):
     sub = 1
     for i in range(len(val)):
         if not val[i].isalpha():
-            sub = int(find_num(i, val))
+            sub = float(find_num(i, val))
             sub *= num
             build += str(sub)
             i += len(find_num(i, val)) - 1
@@ -57,7 +57,7 @@ def distrib_parenth(val):
         close = val.find(')', op)
         between = val[op+1:close]
         if close+1 < len(val) and not val[close+1].isalpha() and val[close+1] != '':
-            num = int(val[close+1])
+            num = float(val[close+1])
             val = val[:op] + distribute(between, num) + val[close+2:]
         else:
             val = val[:op] + distribute(between, num) + val[close+1:]
@@ -98,7 +98,7 @@ def strip_coeff(val):
     i = 0
     while i < len(val):
         if not val[i].isalpha() and val[i] != ',':
-            num = int(find_num(i, val))
+            num = float(find_num(i, val))
             add(num, symb)
             coeff = True
         if val[i] == ',':

--- a/calcmass/mass.py
+++ b/calcmass/mass.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 from __future__ import print_function
-from pt_data import masses
+from calcmass.pt_data import masses
 val = ""
 multiples = {}
 


### PR DESCRIPTION
e.g.
```
$ python3 __main__.py Li1.2Ni0.13Mn0.54Co0.13O2
85.28600
```
